### PR TITLE
fix(deps): add overrides to resolve all security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1837,31 +1837,6 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/@gulp-sourcemaps/identity-map/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@gulp-sourcemaps/identity-map/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
 		"node_modules/@gulp-sourcemaps/identity-map/node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2747,16 +2722,6 @@
 				"ms": "2.0.0"
 			}
 		},
-		"node_modules/babel-core/node_modules/json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
 		"node_modules/babel-core/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2803,6 +2768,19 @@
 				"babel-types": "^6.24.1"
 			}
 		},
+		"node_modules/babel-helper-builder-binary-assignment-operator-visitor/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
 		"node_modules/babel-helper-call-delegate": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
@@ -2814,6 +2792,19 @@
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-helper-call-delegate/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-helper-define-map": {
@@ -2829,6 +2820,19 @@
 				"lodash": "^4.17.4"
 			}
 		},
+		"node_modules/babel-helper-define-map/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
 		"node_modules/babel-helper-explode-assignable-expression": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
@@ -2839,6 +2843,19 @@
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-helper-explode-assignable-expression/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-helper-function-name": {
@@ -2855,6 +2872,19 @@
 				"babel-types": "^6.24.1"
 			}
 		},
+		"node_modules/babel-helper-function-name/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
 		"node_modules/babel-helper-get-function-arity": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
@@ -2864,6 +2894,19 @@
 			"dependencies": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-helper-get-function-arity/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-helper-hoist-variables": {
@@ -2877,6 +2920,19 @@
 				"babel-types": "^6.24.1"
 			}
 		},
+		"node_modules/babel-helper-hoist-variables/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
 		"node_modules/babel-helper-optimise-call-expression": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
@@ -2886,6 +2942,19 @@
 			"dependencies": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-helper-optimise-call-expression/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-helper-regex": {
@@ -2898,6 +2967,19 @@
 				"babel-runtime": "^6.26.0",
 				"babel-types": "^6.26.0",
 				"lodash": "^4.17.4"
+			}
+		},
+		"node_modules/babel-helper-regex/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-helper-remap-async-to-generator": {
@@ -2914,6 +2996,19 @@
 				"babel-types": "^6.24.1"
 			}
 		},
+		"node_modules/babel-helper-remap-async-to-generator/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
 		"node_modules/babel-helper-replace-supers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -2927,6 +3022,19 @@
 				"babel-template": "^6.24.1",
 				"babel-traverse": "^6.24.1",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-helper-replace-supers/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-helpers": {
@@ -3069,6 +3177,19 @@
 				"lodash": "^4.17.4"
 			}
 		},
+		"node_modules/babel-plugin-transform-es2015-block-scoping/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
 		"node_modules/babel-plugin-transform-es2015-classes": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
@@ -3085,6 +3206,19 @@
 				"babel-template": "^6.24.1",
 				"babel-traverse": "^6.24.1",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-plugin-transform-es2015-classes/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-plugin-transform-es2015-computed-properties": {
@@ -3119,6 +3253,19 @@
 				"babel-types": "^6.24.1"
 			}
 		},
+		"node_modules/babel-plugin-transform-es2015-duplicate-keys/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
 		"node_modules/babel-plugin-transform-es2015-for-of": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
@@ -3139,6 +3286,19 @@
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-plugin-transform-es2015-function-name/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-plugin-transform-es2015-literals": {
@@ -3174,6 +3334,19 @@
 				"babel-runtime": "^6.26.0",
 				"babel-template": "^6.26.0",
 				"babel-types": "^6.26.0"
+			}
+		},
+		"node_modules/babel-plugin-transform-es2015-modules-commonjs/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-plugin-transform-es2015-modules-systemjs": {
@@ -3226,6 +3399,19 @@
 				"babel-types": "^6.24.1"
 			}
 		},
+		"node_modules/babel-plugin-transform-es2015-parameters/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
 		"node_modules/babel-plugin-transform-es2015-shorthand-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
@@ -3235,6 +3421,19 @@
 			"dependencies": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-plugin-transform-es2015-shorthand-properties/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-plugin-transform-es2015-spread": {
@@ -3257,6 +3456,19 @@
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-plugin-transform-es2015-sticky-regex/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-plugin-transform-es2015-template-literals": {
@@ -3363,6 +3575,19 @@
 			"dependencies": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"node_modules/babel-plugin-transform-strict-mode/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/babel-polyfill": {
@@ -3489,51 +3714,38 @@
 			}
 		},
 		"node_modules/babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
+			"name": "@babel/traverse",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.28.5",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.28.5",
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.28.5",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
-		},
-		"node_modules/babel-traverse/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/babel-traverse/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"name": "@babel/types",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+			"integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/babylon": {
@@ -5386,16 +5598,6 @@
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/glogg": {
 			"version": "2.2.0",
@@ -7363,6 +7565,19 @@
 				"babel-runtime": "^6.18.0",
 				"babel-types": "^6.19.0",
 				"private": "^0.1.6"
+			}
+		},
+		"node_modules/regenerator-transform/node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"node_modules/regexpu-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "validation-form",
-	"version": "2.2.6",
+	"version": "2.2.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "validation-form",
-			"version": "2.2.6",
+			"version": "2.2.7",
 			"license": "ISC",
 			"devDependencies": {
 				"@babel/core": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.2.6",
+	"version": "2.2.7",
 	"name": "validation-form",
 	"description": "Customized form with validation for different types of fields.",
 	"author": "beatrizsmerino@gmail.com",

--- a/package.json
+++ b/package.json
@@ -37,5 +37,20 @@
 		"node": "20.18.0",
 		"npm": "10.8.2",
 		"gulp-cli": "3.0.0"
+	},
+	"overrides": {
+		"json5": "^2.2.3",
+		"postcss": "^8.4.31",
+		"@gulp-sourcemaps/identity-map": {
+			"postcss": "^8.4.31"
+		},
+		"babel-core": {
+			"json5": "^2.2.3",
+			"babel-traverse": "npm:@babel/traverse@^7.28.5",
+			"babel-types": "npm:@babel/types@^7.28.5"
+		},
+		"babel-preset-env": {
+			"babel-traverse": "npm:@babel/traverse@^7.28.5"
+		}
 	}
 }


### PR DESCRIPTION
# fix(deps): add overrides to resolve all security vulnerabilities

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 12-04-2026 | 09-05-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| <img width="726" alt="Screenshot 2025-11-21 a las 2 08 13" src="https://github.com/user-attachments/assets/7bc22c2f-4c2c-4860-b417-a1aea2347350" /> | <img width="671" alt="Screenshot 2025-11-21 a las 2 06 30" src="https://github.com/user-attachments/assets/4a44a67b-38c2-4c34-b1e7-2728d1a7f941" /> |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

> [!CAUTION]
> ```bash
> $ npm audit
> 29 vulnerabilities (3 moderate, 2 high, 24 critical)
> ```

- Add npm `overrides` section to package.json to force secure versions of transitive dependencies, eliminating all 29 security vulnerabilities (100% reduction)

## 📋 Changes Made

### Dependencies
- Add `overrides` section to `package.json` with:
  - `json5`: ^2.2.3 (fixes HIGH severity prototype pollution vulnerability)
  - `postcss`: ^8.4.31 (fixes MODERATE severity line return parsing error)
  - `postcss`: ^8.4.31 in `@gulp-sourcemaps/identity-map` (fixes MODERATE severity parsing error)
  - `babel-traverse`: npm:@babel/traverse@^7.28.5 in `babel-core` (fixes CRITICAL severity arbitrary code execution)
  - `babel-types`: npm:@babel/types@^7.28.5 in `babel-core` (for compatibility)
  - `babel-traverse`: npm:@babel/traverse@^7.28.5 in `babel-preset-env` (fixes CRITICAL severity issues)
- Update `package-lock.json` with new dependency resolutions

### Version
- Update version to 2.2.7

## 🧪 Tests

- [x] Verify vulnerability reduction:

```bash
npm audit
```
- [x] Verify `Gulp` works correctly:

```bash
npx gulp --version
```
- [x] Verify no regression in existing functionality

## 📌 Notes

### Vulnerable packages
| Package | Version | Severity | Dependency chain | Advisory |
| --- | --- | --- | --- | --- |
| `babel-traverse` | `<7.0.0` | ⚫ | `babel-core` → `babel-traverse`<br>`babel-preset-env` → `babel-traverse` | [GHSA-67hx-6x53-jw92](https://github.com/advisories/GHSA-67hx-6x53-jw92) |
| `json5` | `<2.2.3` | 🔴 | `babel-core` → `json5` | [GHSA-9c47-m6qq-7p4h](https://github.com/advisories/GHSA-9c47-m6qq-7p4h) |
| `postcss` | `<8.4.31` | 🟡 | `@gulp-sourcemaps/identity-map` → `postcss` | [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) |

### Security overrides
| Package | Version | Severity | Advisory |
| --- | --- | --- | --- |
| `babel-traverse` | `7.28.5` | ⚫ | [GHSA-67hx-6x53-jw92](https://github.com/advisories/GHSA-67hx-6x53-jw92) |
| `babel-types` | `7.28.5` | ⚫ | [GHSA-67hx-6x53-jw92](https://github.com/advisories/GHSA-67hx-6x53-jw92) |
| `json5` | `2.2.3` | 🔴 | [GHSA-9c47-m6qq-7p4h](https://github.com/advisories/GHSA-9c47-m6qq-7p4h) |
| `postcss` | `8.4.31` | 🟡 | [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) |

### Vulnerability reduction summary after fix
| Severity | Before | After | Reduction |
| --- | --- | --- | --- |
| ⚫ CRITICAL | 24 | 0 | 100% |
| 🔴 HIGH | 2 | 0 | 100% |
| 🟡 MODERATE | 3 | 0 | 100% |
| **TOTAL** | **29** | **0** | **100%** |

> [!TIP]
> ```bash
> $ npm audit
> 0 vulnerabilities
> ```

**Reduction:** 29 → 0 vulnerabilities (100% reduction), all CRITICAL severity resolved

## 🔗 References

### Documentation
- [GHSA-67hx-6x53-jw92](https://github.com/advisories/GHSA-67hx-6x53-jw92)
- [GHSA-9c47-m6qq-7p4h](https://github.com/advisories/GHSA-9c47-m6qq-7p4h)
- [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
- https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides

### Related Issues
- Closes #359