### PR TITLE
hotfix(2.4.1): update commitlint config to match standard across repositories

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,16 +1,42 @@
 export default {
-	extends: [
+	"extends": [
 		"@commitlint/config-conventional",
 	],
-	rules: {
-		'body-max-line-length': [
+	"rules": {
+		"body-max-line-length": [
 			2,
-			'always',
-			800
+			"always",
+			10000,
 		],
 		"footer-leading-blank": [
 			0,
 			"always",
 		],
-	}
+		"footer-max-line-length": [
+			2,
+			"always",
+			10000,
+		],
+		"header-max-length": [
+			2,
+			"always",
+			150,
+		],
+		"type-enum": [
+			2,
+			"always",
+			[
+				"build",
+				"ci",
+				"docs",
+				"feat",
+				"fix",
+				"perf",
+				"refactor",
+				"revert",
+				"style",
+				"test",
+			],
+		],
+	},
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -7,6 +7,10 @@ export default {
 			2,
 			'always',
 			800
-		]
+		],
+		"footer-leading-blank": [
+			0,
+			"always",
+		],
 	}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "validation-form",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "validation-form",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "ISC",
 			"devDependencies": {
 				"@babel/core": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"name": "validation-form",
 	"description": "Customized form with validation for different types of fields.",
 	"author": "beatrizsmerino@gmail.com",


### PR DESCRIPTION
# hotfix(2.4.1): update commitlint config to match standard across repositories

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | XS | 12-04-2026 | 09-05-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

- Update the commitlint configuration to match the standard used across all repositories

## 📋 Changes Made

### Configuration
- Update `body-max-line-length` rule from 800 to 10000 characters
- Add `footer-leading-blank` rule disabled (value 0) to avoid warnings
- Add `footer-max-line-length` rule with 10000 characters limit
- Add `header-max-length` rule with 150 characters limit
- Add `type-enum` rule with standard conventional commit types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- Standardize code style: use double quotes for object keys and add trailing commas

### Version
- Bump version from `2.4.0` to `2.4.1` in `package.json` and `package-lock.json`

## 🧪 Tests

- [x] Run `npm run build` without errors:

```bash
npm run build
```
- [x] Verify the code follows the project's style guidelines
- [x] Perform a manual self-review of the code
- [x] Verify commits don't show `footer-leading-blank` warning

## 📌 Notes

The commitlint configuration was inconsistent with other repositories, causing warnings like `footer must have leading blank line [footer-leading-blank]` during commits.

## 🔗 References

### Related Issues
- Closes #377