### PR TITLE
hotfix(2.6.2): stylelint configuration alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "validation-form",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "validation-form",
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"name": "validation-form",
 	"private": true,
 	"description": "Customized form with validation for different types of fields.",

--- a/src/sass/base/_base-reset-ericmeyer.scss
+++ b/src/sass/base/_base-reset-ericmeyer.scss
@@ -125,10 +125,10 @@ q {
 	quotes: none;
 }
 
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
+blockquote::before,
+blockquote::after,
+q::before,
+q::after {
 	content: "";
 	content: none;
 }

--- a/src/sass/base/_base-reset-personal.scss
+++ b/src/sass/base/_base-reset-personal.scss
@@ -4,8 +4,8 @@
 
 * {
 	&,
-	&:before,
-	&:after {
+	&::before,
+	&::after {
 		box-sizing: border-box;
 	}
 }

--- a/src/sass/components/_components-form-field-check.scss
+++ b/src/sass/components/_components-form-field-check.scss
@@ -46,7 +46,7 @@
 		}
 
 		// Show the checkmark when checked
-		&:checked ~ .field-check__mark:after {
+		&:checked ~ .field-check__mark::after {
 			display: block;
 		}
 
@@ -68,7 +68,7 @@
 		background-color: $field-check-input-background-color;
 
 		// Create the checkmark/indicator (hidden when not checked)
-		&:after {
+		&::after {
 			content: "";
 			display: none;
 			position: absolute;

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -149,9 +149,9 @@ module.exports = {
 			},
 		],
 		"selector-id-pattern": [
-			"error",
+			"^[a-z][a-zA-Z0-9]*$",
 			{
-				"format": "camelCase",
+				"message": "Expected ID selector to be camelCase",
 			},
 		],
 		"selector-max-compound-selectors": null,

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -132,12 +132,17 @@ module.exports = {
 		"scss/no-global-function-names": null,
 
 		// Allows: BEM pattern (block__element--modifier) + CKEditor classes (cke_*)
+		// Examples (BEM): card, card-product, card--primary, card-product--primary, card-product__title, card-product__title-text, card-product__title--primary, card-product__title--primary-dark, card-product__title--primary-2, card-product__title--2, is-active
+		// Examples (CKEditor): cke_button, cke_btn_locked, cke_button__bold_icon
 		"selector-class-pattern": [
 			"^(cke_[a-z]+|([a-z]+[a-z0-9]*)(-[a-z0-9]+)*(__[a-z]+[a-z0-9]+(-[a-z0-9]+)*)?(--[a-z0-9]+(-[a-z0-9]+)*)?)$",
 			{
 				"resolveNestedSelectors": true,
 			},
 		],
+
+		// Allows: camelCase pattern
+		// Examples (camelCase): header, mainContent, userProfile2
 		"selector-id-pattern": [
 			"^[a-z][a-zA-Z0-9]*$",
 			{

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -143,7 +143,7 @@ module.exports = {
 
 		// Allows: BEM pattern (block__element--modifier) + CKEditor classes (cke_*)
 		"selector-class-pattern": [
-			"^(cke_[a-z]+|([a-z]+[a-z0-9]*)(-[a-z0-9]+)*(__[a-z]+[a-z0-9]+(-[a-z0-9]+)*)?(--[a-z]+[a-z0-9]+(-[a-z0-9]+)*)?)$",
+			"^(cke_[a-z]+|([a-z]+[a-z0-9]*)(-[a-z0-9]+)*(__[a-z]+[a-z0-9]+(-[a-z0-9]+)*)?(--[a-z0-9]+(-[a-z0-9]+)*)?)$",
 			{
 				"resolveNestedSelectors": true,
 			},

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -18,6 +18,15 @@ module.exports = {
 		"stylelint-scss",
 	],
 	"rules": {
+		"annotation-no-unknown": [
+			true,
+			{
+				"ignoreAnnotations": [
+					"default",
+					"global",
+				],
+			},
+		],
 		"at-rule-empty-line-before": [
 			"always",
 			{
@@ -92,15 +101,6 @@ module.exports = {
 				"ignore": [
 					"after-comment",
 					"inside-single-line-block",
-				],
-			},
-		],
-		"annotation-no-unknown": [
-			true,
-			{
-				"ignoreAnnotations": [
-					"default",
-					"global",
 				],
 			},
 		],

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -4,16 +4,6 @@ module.exports = {
 		"stylelint-config-sass-guidelines",
 		"stylelint-config-property-sort-order-smacss",
 	],
-	"overrides": [
-		{
-			"files": [
-				"src/sass/abstracts/mixins/_abstracts-mixins-media.scss",
-			],
-			"rules": {
-				"media-query-no-invalid": null,
-			},
-		},
-	],
 	"plugins": [
 		"stylelint-scss",
 	],
@@ -187,4 +177,14 @@ module.exports = {
 		"@stylistic/indentation": "tab",
 		"@stylistic/string-quotes": "double",
 	},
+	"overrides": [
+		{
+			"files": [
+				"src/sass/abstracts/mixins/_abstracts-mixins-media.scss",
+			],
+			"rules": {
+				"media-query-no-invalid": null,
+			},
+		},
+	],
 };

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -168,7 +168,7 @@ module.exports = {
 		"selector-pseudo-class-no-unknown": [
 			true,
 		],
-		"selector-pseudo-element-colon-notation": "single",
+		"selector-pseudo-element-colon-notation": "double",
 		"selector-pseudo-element-no-unknown": [
 			true,
 		],


### PR DESCRIPTION
# hotfix(2.6.2): stylelint configuration alignment

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 6h | P0 | L | 18-04-2026 | 09-05-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [ ] CI/CD

## 📝 Summary

- Hotfix release with stylelint configuration alignment to match the shared format used across other repos

## 📋 Changes Made

### Bug Fixes
- Change `selector-pseudo-element-colon-notation` from `single` to `double` in `stylelint.config.cjs`
- Allow numeric BEM modifiers in `selector-class-pattern` in `stylelint.config.cjs`
- Fix `selector-id-pattern` to allow `camelCase` IDs in `stylelint.config.cjs`

### Documentation
- Add explanatory comments to selector pattern regex in `stylelint.config.cjs`

### Configuration
- Format pseudo-elements with double colon notation in SCSS files
- Sort rules alphabetically for consistency with other repos in `stylelint.config.cjs`
- Move `overrides` section after `rules` for consistency in `stylelint.config.cjs`

### Dependencies
- Reinstall npm packages to update `package-lock.json`

### Version
- Bump version from `2.6.1` to `2.6.2`

## 🧪 Tests

- [x] All npm scripts run without errors
- [x] Stylelint configuration matches shared format

## 🔗 References

### Documentation
- https://getbem.com/naming/
- https://ckeditor.com/docs/ckeditor4/latest/

### Related Issues
- Closes #487
- Closes #488
- Closes #489
- Closes #490
- Closes #491
- Closes #492